### PR TITLE
Java codelab: start_here now builds right after protos defined

### DIFF
--- a/codelabs/grpc-java-getting-started/start_here/src/main/java/io/grpc/examples/routeguide/RouteGuideClient.java
+++ b/codelabs/grpc-java-getting-started/start_here/src/main/java/io/grpc/examples/routeguide/RouteGuideClient.java
@@ -28,7 +28,7 @@ public class RouteGuideClient {
      * Codelab Hint: Create a blocking stub for your service
      * using the code generated from the proto file (RouteGuideGrpc)
      ****************************************************************/
-    blockingStub = null;
+    blockingStub = null; // Replace
   }
 
   /**
@@ -39,12 +39,12 @@ public class RouteGuideClient {
 
     Point request = Point.newBuilder().setLatitude(lat).setLongitude(lon).build();
 
-    Feature feature = null;
+    Feature feature;
     try {
       /****************************************************************
        * Codelab Hint: Use the blocking stub to make an RPC call to getFeature
-       *
        ****************************************************************/
+      feature = null; // Replace
 
     } catch (StatusRuntimeException e) {
       warning("RPC failed: {0}", e.getStatus());

--- a/codelabs/grpc-java-getting-started/start_here/src/main/java/io/grpc/examples/routeguide/RouteGuideClient.java
+++ b/codelabs/grpc-java-getting-started/start_here/src/main/java/io/grpc/examples/routeguide/RouteGuideClient.java
@@ -27,9 +27,8 @@ public class RouteGuideClient {
     /****************************************************************
      * Codelab Hint: Create a blocking stub for your service
      * using the code generated from the proto file (RouteGuideGrpc)
-     *
-     blockingStub =
      ****************************************************************/
+    blockingStub = null;
   }
 
   /**
@@ -40,7 +39,7 @@ public class RouteGuideClient {
 
     Point request = Point.newBuilder().setLatitude(lat).setLongitude(lon).build();
 
-    Feature feature;
+    Feature feature = null;
     try {
       /****************************************************************
        * Codelab Hint: Use the blocking stub to make an RPC call to getFeature
@@ -64,7 +63,7 @@ public class RouteGuideClient {
   }
 
   /** Issues several different requests and then exits. */
-  public static void main(String[] args)  {
+  public static void main(String[] args) throws InterruptedException {
     String target = "localhost:8980";
     if (args.length > 0) {
       if ("--help".equals(args[0])) {
@@ -76,9 +75,9 @@ public class RouteGuideClient {
       target = args[0];
     }
 
-        /***************************************************************
-         * Codelab Hint: create a channel using target defined above
-         ***************************************************************/
+     /***************************************************************
+      * Codelab Hint: create a channel using target defined above
+      ***************************************************************/
      ManagedChannel channel = null; // Replace
 
     try {

--- a/codelabs/grpc-java-getting-started/start_here/src/main/java/io/grpc/examples/routeguide/RouteGuideServer.java
+++ b/codelabs/grpc-java-getting-started/start_here/src/main/java/io/grpc/examples/routeguide/RouteGuideServer.java
@@ -36,21 +36,20 @@ public class RouteGuideServer {
     this.port = port;
     /****************************************************************
      * Codelab Hint: Create a server object using the passed in serverBuilder
-     *
-    server =
      ****************************************************************/
+    server = null;
   }
 
   /** Start serving requests. */
   public void start() throws IOException {
 
-  /****************************************************************
-   * Codelab Hint: Start the server
-   ****************************************************************/
+    /****************************************************************
+     * Codelab Hint: Start the server
+     ****************************************************************/
 
     logger.info("Server started, listening on " + port);
 
-// Always configure a shutdown hook so that you can cleanly stop your server
+    // Always configure a shutdown hook so that you can cleanly stop your server
     Runtime.getRuntime().addShutdownHook(new Thread() {
       @Override
       public void run() {
@@ -78,9 +77,9 @@ public class RouteGuideServer {
    */
   private void blockUntilShutdown() throws InterruptedException {
     if (server != null) {
-  /****************************************************************
-   * Codelab Hint: wait for server termination
-   ****************************************************************/
+      /****************************************************************
+       * Codelab Hint: wait for server termination
+       ****************************************************************/
     }
   }
 
@@ -114,11 +113,10 @@ public class RouteGuideServer {
      */
     @Override
     public void getFeature(Point request, StreamObserver<Feature> responseObserver) {
-  /****************************************************************
-   * Codelab Hint: use checkFeature so send an appropriate response
-   * and mark the RPC complete
-   ****************************************************************/
-
+      /****************************************************************
+       * Codelab Hint: use checkFeature so send an appropriate response
+       * and mark the RPC complete
+       ****************************************************************/
     }
 
     /**


### PR DESCRIPTION
1. With this, `../gradlew build` will work right after the first step - adding proto definitions.
2. Minor indent fixes for the comments