### PR TITLE
build: Bump gRPC version to 1.76.0 and require C++17

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/codelabs/grpc-cpp-opentelemetry/bazel-*

--- a/codelabs/grpc-cpp-opentelemetry/.bazelrc
+++ b/codelabs/grpc-cpp-opentelemetry/.bazelrc
@@ -3,18 +3,19 @@
 # Bazel 7 begins to enable module by default which breaks gRPC build.
 # Therefore, this option is disabled until gRPC works with bzlmod.
 common --enable_bzlmod=false
+common --enable_workspace=true
 
 # for platform-appropriate cxxopts
 common --enable_platform_specific_config
 
-build:windows --cxxopt='/std:c++14'
-build:windows --host_cxxopt='/std:c++14'
-build:linux   --cxxopt='-std=c++14'
-build:linux   --host_cxxopt='-std=c++14'
-build:macos   --cxxopt='-std=c++14'
-build:macos   --host_cxxopt='-std=c++14'
-build:freebsd   --cxxopt='-std=c++14'
-build:freebsd   --host_cxxopt='-std=c++14'
+build:windows --cxxopt='/std:c++17'
+build:windows --host_cxxopt='/std:c++17'
+build:linux   --cxxopt='-std=c++17'
+build:linux   --host_cxxopt='-std=c++17'
+build:macos   --cxxopt='-std=c++17'
+build:macos   --host_cxxopt='-std=c++17'
+build:freebsd   --cxxopt='-std=c++17'
+build:freebsd   --host_cxxopt='-std=c++17'
 
 # TODO(yashkt): Remove these once upb is upgraded to 25.x or later
 build:linux --copt=-Wno-typedef-redefinition

--- a/codelabs/grpc-cpp-opentelemetry/WORKSPACE
+++ b/codelabs/grpc-cpp-opentelemetry/WORKSPACE
@@ -4,9 +4,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "com_github_grpc_grpc",
-    strip_prefix = "grpc-1.65.5",
+    strip_prefix = "grpc-1.76.0",
     urls = [
-        "https://github.com/grpc/grpc/archive/v1.65.5.tar.gz",
+        "https://github.com/grpc/grpc/archive/v1.76.0.tar.gz",
     ],
 )
 


### PR DESCRIPTION
This PR introduces two key updates:

* **gRPC Version Upgrade:** The gRPC version has been upgraded from `1.65.5` to `1.76.0`. 
* **C++17 Standard:** The project's minimum required C++ standard has been increased from C++14 to C++17. 